### PR TITLE
Fix EOF flag setting in mio_gets() when \n is at the end of file

### DIFF
--- a/mio/mio-memory.c
+++ b/mio/mio-memory.c
@@ -357,6 +357,7 @@ mem_gets (MIO    *mio,
   char *rv = NULL;
   
   if (size > 0) {
+    int newline = FALSE;
     size_t i = 0;
     
     if (mio->impl.mem.ungetch != EOF) {
@@ -370,6 +371,7 @@ mem_gets (MIO    *mio,
       mio->impl.mem.pos++;
       if (s[i] == '\n') {
         i++;
+        newline = TRUE;
         break;
       }
     }
@@ -377,7 +379,7 @@ mem_gets (MIO    *mio,
       s[i] = 0;
       rv = s;
     }
-    if (mio->impl.mem.pos >= mio->impl.mem.size) {
+    if (!newline && mio->impl.mem.pos >= mio->impl.mem.size) {
       mio->impl.mem.eof = TRUE;
     }
   }

--- a/tests/main.c
+++ b/tests/main.c
@@ -46,6 +46,9 @@ create_input_file (const gchar *filename)
     rv = TRUE;
     for (i = 0; rv && i < n; i++) {
       gint c = (gint) g_random_int_range (0, 256);
+
+      if (i == n - 1)
+        c = '\n';
       
       if (putc (c, fpout) == EOF) {
         g_critical ("Failed to write 1 bytes of data: %s",
@@ -526,6 +529,15 @@ test_read_gets (void)
   
   TEST_CREATE_MIO (mio, TEST_FILE_R, FALSE)
   
+  TEST_SEEK (c, mio, -1, SEEK_END, 0);
+  TEST_GETS (sr, mio, s, size, 0);
+  TEST_EOF (c, mio);
+  TEST_GETS (sr, mio, s, size, 0);
+  TEST_EOF (c, mio);
+
+  TEST_SEEK (c, mio, 0, SEEK_SET, 0);
+  TEST_CLEARERR (mio);
+
   loop (i, 3) {
     TEST_GETS (sr, mio, s, size, 0);
   }


### PR DESCRIPTION
When the input file looks like

abcd\nEOF

and mio_gets() is called, it returns "abcd\n" and sets the EOF flag.
However, fgets() doesn't set EOF in this case - it only sets it in the
subsequent call. Fix this.

The unit test input file had to be modified to always put \n at the end
of the file in order to test this issue.

Backport of the fix from https://github.com/universal-ctags/ctags/pull/1091
